### PR TITLE
feat: implement dark mode toggle with localStorage and system preference

### DIFF
--- a/components/darkToggle.tsx
+++ b/components/darkToggle.tsx
@@ -6,22 +6,40 @@ export default function DarkToggle() {
   const [isDark, setIsDark] = useState(false);
 
   useEffect(() => {
-    /* 
-      Implement logic to set the initial theme based on localStorage 
-      and system preference (prefers-color-scheme). 
-      Also update `isDark` state accordingly.
-      See https://tailwindcss.com/docs/dark-mode
-     */
+    const savedTheme = localStorage.getItem('theme');
+
+    if(savedTheme){
+      if(savedTheme === 'dark'){
+        document.documentElement.classList.add('dark');
+        setIsDark(true);
+      }else{
+        document.documentElement.classList.remove('dark');
+        setIsDark(false);
+      }
+    }else{
+      const prefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)",
+      ).matches;
+      if (prefersDark) {
+        document.documentElement.classList.add("dark");
+        setIsDark(true);
+      } else {
+        document.documentElement.classList.remove("dark");
+        setIsDark(false);
+      }
+    }
   }, []);
 
   const toggleTheme = () => {
-    /* 
-    Implement toggle between dark and light theme:
-      - Update `document.documentElement.classList`
-      - Persist theme choice in localStorage
-      - Update `isDark` state
-    */
-    setIsDark(!isDark);
+    if(isDark){
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+      setIsDark(false);
+    }else{
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+      setIsDark(true);
+    }
   };
 
   return (


### PR DESCRIPTION
## Description

**Summary of Changes**
- Implemented logic for the `DarkToggle` component:
  - On initial load:
    - Checks `localStorage.theme`.
    - Falls back to system `prefers-color-scheme`.
    - Applies/removes the `dark` class on `<html>`.
    - Updates the `isDark` state accordingly.
  - On toggle:
    - Toggles the `dark` class on `<html>`.
    - Saves the user’s choice in `localStorage`.
    - Updates `isDark` so the UI

**Related Issue**
Closes #1 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- Verified that if `localStorage.theme` is set to `dark`, the app loads in dark mode.
- Verified that if no value is set, system `prefers-color-scheme` is respected.
- Verified toggle updates both UI and `localStorage`.
- Confirmed dark mode persists across reloads.

## Screenshot
**Dark Mode Active**
toggle on left, moon icon visible

**Light Mode Active**
toggle on right, sun icon visible
